### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "urls": [
+    ["rotary.py", "github:kevinkk525/SonosRemote/src/lib/rotary.py"],
+    ["rotary_irq_esp.py", "github:kevinkk525/SonosRemote/src/lib/rotary_irq_esp.py"],
+    ["aswitch.py", "github:kevinkk525/SonosRemote/src/lib/aswitch.py"],
+    ["usyslog.py", "github:kevinkk525/SonosRemote/src/lib/usyslog.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the module compatible with the MicroPython Package Manager (MIP).

With this change, users can install the module using: \

This PR is part of an effort to add package.json to popular MicroPython libraries.